### PR TITLE
fixes a mistake in the api url

### DIFF
--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -16,7 +16,7 @@
 
 	<type type="tosca.Server" extends="configuration.HttpConnection">
         <property name="scriptLocation" default="tosca/TestToscaConnection.py" hidden="true" />
-		<property name="apiUrl" label="API URL" default="/tcrest/toscacommander/" required="false" />
+		<property name="apiUrl" label="API URL" default="/rest/toscacommander/" required="false" />
     </type>
 
 	<type type="tosca.executeTestEvent" extends="xlrelease.PythonScript" >


### PR DESCRIPTION
The default api url of the Tricentis Tosca Rest API is:  http://TOSCASERVER/Rest/ToscaCommander/COMMAND and not .../tcrest/...